### PR TITLE
Fix failing test case for writing to fields 0, 1, 2, and then 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with libtiva++.  If not, see <https://www.gnu.org/licenses/>.
 
-AC_INIT([libtiva++], [0.1.0])
+AC_INIT([libtiva++], [0.1.1])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 PKG_CHECK_MODULES([TIVASDK], [tivasdk])
 AC_MSG_CHECKING([for [TIVASDK_INIT]])

--- a/test/Register/main.cpp
+++ b/test/Register/main.cpp
@@ -65,10 +65,6 @@ extern "C" void main() {
                  Nibble1Field, Nibble2Field, Nibble3Field, Nibble4Field>
       Register0(BasicRegister0);
 
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-  volatile auto B{A};
-#pragma GCC diagnostic pop
-
   // # Paths
   // * 0
   // * 1
@@ -81,34 +77,24 @@ extern "C" void main() {
   // 5 choose 1 = 5! / (1! * 4!) = 5
 
   // 0
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>()).write();
-  B = A;
   A = 0xff'ff'ff'ffu;
-  B = A;
+  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>()).write();
 
   // 1
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>()).write();
-  B = A;
   A = 0xff'ff'ff'ffu;
-  B = A;
+  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>()).write();
 
   // 2
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>()).write();
-  B = A;
   A = 0xff'ff'ff'ffu;
-  B = A;
+  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>()).write();
 
   // 3
-  Register0.write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>()).write();
-  B = A;
   A = 0xff'ff'ff'ffu;
-  B = A;
+  Register0.write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>()).write();
 
   // 4
-  Register0.write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>()).write();
-  B = A;
   A = 0xff'ff'ff'ffu;
-  B = A;
+  Register0.write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>()).write();
 
   // # Paths
   // * 0-1
@@ -127,84 +113,64 @@ extern "C" void main() {
   // 5 choose 2 = 5! / (2! * 3!) = 10 paths
 
   // 0-1
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-2
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-3
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 1-2
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 1-3
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 1-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 2-3
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 2-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // # Paths
   // * 0-1-2
@@ -223,94 +189,74 @@ extern "C" void main() {
   // 5 choose 3 = 5! / (3! * 2!) = 10 paths
 
   // 0-1-2
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-1-3
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-1-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-2-3
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-2-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 0-3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 1-2-3
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 1-2-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 1-3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // 2-3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // # Paths
   // * 0-1-2-3
@@ -324,54 +270,44 @@ extern "C" void main() {
   // 5 choose 4 = 5! / (4! * 1!) = 5 paths
 
   // * 0-1-2-3
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // * 0-1-2-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // * 0-1-3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // * 0-2-3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // * 1-2-3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   // # Paths
   // * 0-1-2-3-4
@@ -381,18 +317,16 @@ extern "C" void main() {
   // 5 choose 5 = 5! / (5! * 0!) = 1 path
 
   // 0-1-2-3-4
+  A = 0xff'ff'ff'ffu;
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
-  B = A;
-  A = 0xff'ff'ff'ffu;
-  B = A;
 
   for (;;)
     ;
 }
 
-volatile std::uint32_t A{0xff'ff'ff'ffu};
+volatile std::uint32_t A{0x00'00'00'00u};

--- a/test/Register/main.cpp
+++ b/test/Register/main.cpp
@@ -56,7 +56,7 @@ public:
   constexpr Nibble4Field(const std::uint32_t Value) : BasicField(Value) {}
 };
 
-extern std::uint32_t A;
+extern volatile std::uint32_t A;
 
 extern "C" void main() {
   constexpr tiva::MemorymappedRegister<std::uint32_t> BasicRegister0(
@@ -83,31 +83,31 @@ extern "C" void main() {
   // 0
   Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>()).write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>()).write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 1
   Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>()).write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>()).write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 2
   Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>()).write();
   B = A;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>()).write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 3
   Register0.write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>()).write();
   B = A;
-  Register0.write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>()).write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 4
   Register0.write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>()).write();
   B = A;
-  Register0.write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>()).write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // # Paths
@@ -131,9 +131,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-2
@@ -141,9 +139,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-3
@@ -151,9 +147,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-4
@@ -161,9 +155,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 1-2
@@ -171,9 +163,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 1-3
@@ -181,9 +171,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 1-4
@@ -191,9 +179,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 2-3
@@ -201,9 +187,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 2-4
@@ -211,9 +195,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 3-4
@@ -221,9 +203,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // # Paths
@@ -248,10 +228,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-1-3
@@ -260,10 +237,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-1-4
@@ -272,10 +246,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-2-3
@@ -284,10 +255,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-2-4
@@ -296,10 +264,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 0-3-4
@@ -308,10 +273,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 1-2-3
@@ -320,10 +282,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 1-2-4
@@ -332,10 +291,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 1-3-4
@@ -344,10 +300,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // 2-3-4
@@ -356,10 +309,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // # Paths
@@ -380,11 +330,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // * 0-1-2-4
@@ -394,11 +340,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // * 0-1-3-4
@@ -408,11 +350,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // * 0-2-3-4
@@ -422,11 +360,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // * 1-2-3-4
@@ -436,11 +370,7 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   // # Paths
@@ -458,16 +388,11 @@ extern "C" void main() {
       .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
       .write();
   B = A;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'0fu>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'f0u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'0f'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'f0'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'0f'00'00u>())
-      .write();
+  A = 0xff'ff'ff'ffu;
   B = A;
 
   for (;;)
     ;
 }
 
-std::uint32_t A{0xff'ff'ff'ffu};
+volatile std::uint32_t A{0xff'ff'ff'ffu};

--- a/test/Register/main.cpp
+++ b/test/Register/main.cpp
@@ -22,50 +22,300 @@
 #include <tiva/Register/Register.h>
 
 class Nibble0Field : public tiva::Field<std::uint32_t, 0x00, 0x03> {
-  using BasicField = tiva::Field<std::uint32_t, 0x00, 0x03>;
+  using FieldType = tiva::Field<std::uint32_t, 0x00, 0x03>;
 
 public:
-  constexpr Nibble0Field(const std::uint32_t Value) : BasicField(Value) {}
+  constexpr Nibble0Field(const std::uint32_t Value) : FieldType(Value) {}
 };
 
 class Nibble1Field : public tiva::Field<std::uint32_t, 0x04, 0x07> {
-  using BasicField = tiva::Field<std::uint32_t, 0x04, 0x07>;
+  using FieldType = tiva::Field<std::uint32_t, 0x04, 0x07>;
 
 public:
-  constexpr Nibble1Field(const std::uint32_t Value) : BasicField(Value) {}
+  constexpr Nibble1Field(const std::uint32_t Value) : FieldType(Value) {}
 };
 
 class Nibble2Field : public tiva::Field<std::uint32_t, 0x08, 0x0b> {
-  using BasicField = tiva::Field<std::uint32_t, 0x08, 0x0b>;
+  using FieldType = tiva::Field<std::uint32_t, 0x08, 0x0b>;
 
 public:
-  constexpr Nibble2Field(const std::uint32_t Value) : BasicField(Value) {}
+  constexpr Nibble2Field(const std::uint32_t Value) : FieldType(Value) {}
 };
 
 class Nibble3Field : public tiva::Field<std::uint32_t, 0x0c, 0x0f> {
-  using BasicField = tiva::Field<std::uint32_t, 0x0c, 0x0f>;
+  using FieldType = tiva::Field<std::uint32_t, 0x0c, 0x0f>;
 
 public:
-  constexpr Nibble3Field(const std::uint32_t Value) : BasicField(Value) {}
+  constexpr Nibble3Field(const std::uint32_t Value) : FieldType(Value) {}
 };
 
 class Nibble4Field : public tiva::Field<std::uint32_t, 0x10, 0x13> {
-  using BasicField = tiva::Field<std::uint32_t, 0x10, 0x13>;
+  using FieldType = tiva::Field<std::uint32_t, 0x10, 0x13>;
 
 public:
-  constexpr Nibble4Field(const std::uint32_t Value) : BasicField(Value) {}
+  constexpr Nibble4Field(const std::uint32_t Value) : FieldType(Value) {}
 };
 
 extern volatile std::uint32_t A;
 
 extern "C" void main() {
-  constexpr tiva::MemorymappedRegister<std::uint32_t> BasicRegister0(
+  constexpr tiva::MemorymappedRegister<std::uint32_t> BaseRegister(
       reinterpret_cast<std::uint32_t>(&A));
-  tiva::Register<decltype(BasicRegister0), 0x00'00'00'00u, Nibble0Field,
+  tiva::Register<decltype(BaseRegister), 0x00'00'00'00u, Nibble0Field>
+      Register0(BaseRegister);
+  tiva::Register<decltype(BaseRegister), 0x00'00'00'00u, Nibble0Field,
+                 Nibble1Field>
+      Register1(BaseRegister);
+  tiva::Register<decltype(BaseRegister), 0x00'00'00'00u, Nibble0Field,
+                 Nibble1Field, Nibble2Field>
+      Register2(BaseRegister);
+  tiva::Register<decltype(BaseRegister), 0x00'00'00'00u, Nibble0Field,
+                 Nibble1Field, Nibble2Field, Nibble3Field>
+      Register3(BaseRegister);
+  tiva::Register<decltype(BaseRegister), 0x00'00'00'00u, Nibble0Field,
                  Nibble1Field, Nibble2Field, Nibble3Field, Nibble4Field>
-      Register0(BasicRegister0);
+      Register4(BaseRegister);
 
-  // # Paths
+  // # 1-Field Register
+
+  // ## 1-Field Paths
+  // * 0
+  //
+  // **Total**: 1 path
+  //
+  // 1 choose 1 = 1! / (1! * 0!) = 1 path
+
+  // 0
+  A = 0xff'ff'ff'ffu;
+  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>()).write();
+
+  // # 2-Field Register
+
+  // ## 1-Field Paths
+  // * 0
+  // * 1
+  //
+  // **Total**: 2 paths
+  //
+  // 2 choose 1 = 2! / (1! * 1!) = 2 paths
+
+  // 0
+  A = 0xff'ff'ff'ffu;
+  Register1.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>()).write();
+
+  // 1
+  A = 0xff'ff'ff'ffu;
+  Register1.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>()).write();
+
+  // ## 2-Field Paths
+  // * 0-1
+  //
+  // **Total**: 1 path
+  //
+  // 2 choose 2 = 2! / (2! * 0!) = 1 path
+
+  // 0-1
+  A = 0xff'ff'ff'ffu;
+  Register1.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write();
+
+  // # 3-Field Register
+
+  // ## 1-Field Paths
+  // * 0
+  // * 1
+  // * 2
+  //
+  // **Total**: 3 paths
+  //
+  // 3 choose 1 = 3! / (1! * 2!) = 3 paths
+
+  // 0
+  A = 0xff'ff'ff'ffu;
+  Register2.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>()).write();
+
+  // 1
+  A = 0xff'ff'ff'ffu;
+  Register2.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>()).write();
+
+  // 2
+  A = 0xff'ff'ff'ffu;
+  Register2.write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>()).write();
+
+  // ## 2-Field Paths
+  // * 0-1
+  // * 0-2
+  // * 1-2
+  //
+  // **Total**: 3 paths
+  //
+  // 3 choose 2 = 3! / (2! * 1!) = 3 paths
+
+  // 0-1
+  A = 0xff'ff'ff'ffu;
+  Register2.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write();
+
+  // 0-2
+  A = 0xff'ff'ff'ffu;
+  Register2.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write();
+
+  // 1-2
+  A = 0xff'ff'ff'ffu;
+  Register2.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write();
+
+  // ## 3-Field Paths
+  // * 0-1-2
+  //
+  // **Total**: 1 path
+  //
+  // 3 choose 3 = 3! / (3! * 0!) = 1 path
+
+  // 0-1-2
+  A = 0xff'ff'ff'ffu;
+  Register2.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write();
+
+  // # 4-Field Register
+
+  // ## 1-Field Paths
+  // * 0
+  // * 1
+  // * 2
+  // * 3
+  //
+  // **Total**: 4 paths
+  //
+  // 4 choose 1 = 4! / (1! * 3!) = 4 paths
+
+  // 0
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>()).write();
+
+  // 1
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>()).write();
+
+  // 2
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>()).write();
+
+  // 3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>()).write();
+
+  // ## 2-Field Paths
+  // * 0-1
+  // * 0-2
+  // * 0-3
+  // * 1-2
+  // * 1-3
+  // * 2-3
+  //
+  // **Total**: 6 paths
+  //
+  // 4 choose 2 = 4! / (2! * 2!) = 6 paths
+
+  // 0-1
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write();
+
+  // 0-2
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write();
+
+  // 0-3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write();
+
+  // 1-2
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write();
+
+  // 1-3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write();
+
+  // 2-3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write();
+
+  // ## 3-Field Paths
+  // * 0-1-2
+  // * 0-1-3
+  // * 0-2-3
+  // * 1-2-3
+  //
+  // **Total**: 4 paths
+  //
+  // 4 choose 3 = 4! / (3! * 1!) = 4 paths
+
+  // 0-1-2
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write();
+
+  // 0-1-3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write();
+
+  // 0-2-3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write();
+
+  // 1-2-3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write();
+
+  // ## 4-Field Paths
+  // * 0-1-2-3
+  //
+  // **Total**: 1 path
+  //
+  // 4 choose 4 = 4! / (4! * 0!) = 1 path
+
+  // 0-1-2-3
+  A = 0xff'ff'ff'ffu;
+  Register3.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write();
+
+  // # 5-Field Register
+
+  // ## 1-Field Paths
   // * 0
   // * 1
   // * 2
@@ -78,25 +328,25 @@ extern "C" void main() {
 
   // 0
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>()).write();
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>()).write();
 
   // 1
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>()).write();
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>()).write();
 
   // 2
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>()).write();
+  Register4.write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>()).write();
 
   // 3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>()).write();
+  Register4.write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>()).write();
 
   // 4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>()).write();
+  Register4.write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>()).write();
 
-  // # Paths
+  // ## 2-Field Paths
   // * 0-1
   // * 0-2
   // * 0-3
@@ -114,65 +364,65 @@ extern "C" void main() {
 
   // 0-1
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
       .write();
 
   // 0-2
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
       .write();
 
   // 0-3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
       .write();
 
   // 0-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 1-2
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
       .write();
 
   // 1-3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
       .write();
 
   // 1-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 2-3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
+  Register4.write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
       .write();
 
   // 2-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
-  // # Paths
+  // ## 3-Field Paths
   // * 0-1-2
   // * 0-1-3
   // * 0-1-4
@@ -190,75 +440,75 @@ extern "C" void main() {
 
   // 0-1-2
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
       .write();
 
   // 0-1-3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
       .write();
 
   // 0-1-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 0-2-3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
       .write();
 
   // 0-2-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 0-3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 1-2-3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
       .write();
 
   // 1-2-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 1-3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // 2-3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
-  // # Paths
+  // ## 4-Field Paths
   // * 0-1-2-3
   // * 0-1-2-4
   // * 0-1-3-4
@@ -271,45 +521,45 @@ extern "C" void main() {
 
   // * 0-1-2-3
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
       .write();
 
   // * 0-1-2-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // * 0-1-3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // * 0-2-3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   // * 1-2-3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
-  // # Paths
+  // ## 5-Field Paths
   // * 0-1-2-3-4
   //
   // **Total**: 1 path
@@ -318,11 +568,11 @@ extern "C" void main() {
 
   // 0-1-2-3-4
   A = 0xff'ff'ff'ffu;
-  Register0.write(tiva::makeField<Nibble0Field, 0x00'00'00'02u>())
-      .write(tiva::makeField<Nibble1Field, 0x00'00'00'20u>())
-      .write(tiva::makeField<Nibble2Field, 0x00'00'02'00u>())
-      .write(tiva::makeField<Nibble3Field, 0x00'00'20'00u>())
-      .write(tiva::makeField<Nibble4Field, 0x00'02'00'00u>())
+  Register4.write(tiva::makeField<Nibble0Field, 0x00'00'00'01u>())
+      .write(tiva::makeField<Nibble1Field, 0x00'00'00'10u>())
+      .write(tiva::makeField<Nibble2Field, 0x00'00'01'00u>())
+      .write(tiva::makeField<Nibble3Field, 0x00'00'10'00u>())
+      .write(tiva::makeField<Nibble4Field, 0x00'01'00'00u>())
       .write();
 
   for (;;)

--- a/tiva/Register/Register.h
+++ b/tiva/Register/Register.h
@@ -166,9 +166,8 @@ template <class BaseRegister, bool MightAllFieldsBeWritten,
 class WriteField0RegisterFields<BaseRegister, MightAllFieldsBeWritten,
                                 RegisterResetValue, RegisterFieldm1,
                                 RegisterFieldm1BaseField, BaseField>
-    : public WriteField0<BaseRegister, MightAllFieldsBeWritten,
-                         RegisterResetValue, RegisterFieldm1,
-                         RegisterFieldm1BaseField> {
+    : public WriteField0<BaseRegister, false, RegisterResetValue,
+                         RegisterFieldm1, RegisterFieldm1BaseField> {
   using WriteField0RegisterFieldsType =
       WriteField0RegisterFields<BaseRegister, MightAllFieldsBeWritten,
                                 RegisterResetValue, RegisterFieldm1,
@@ -180,8 +179,8 @@ class WriteField0RegisterFields<BaseRegister, MightAllFieldsBeWritten,
   friend WriteFieldsle1Type<MightAllFieldsBeWritten>;
   friend WriteFieldsle1Type<false>;
   using WriteField0Type =
-      WriteField0<BaseRegister, MightAllFieldsBeWritten, RegisterResetValue,
-                  RegisterFieldm1, RegisterFieldm1BaseField>;
+      WriteField0<BaseRegister, false, RegisterResetValue, RegisterFieldm1,
+                  RegisterFieldm1BaseField>;
 
 protected:
   using WriteField0Type::getInverseMask;
@@ -287,9 +286,8 @@ template <class BaseRegister, bool MightAllFieldsBeWritten,
 class WriteFieldslege1RegisterFields<BaseRegister, MightAllFieldsBeWritten,
                                      RegisterResetValue, WriteFieldslem1,
                                      WriteFieldslem1BaseField, BaseField>
-    : public WriteFieldslege1<BaseRegister, MightAllFieldsBeWritten,
-                              RegisterResetValue, WriteFieldslem1,
-                              WriteFieldslem1BaseField> {
+    : public WriteFieldslege1<BaseRegister, false, RegisterResetValue,
+                              WriteFieldslem1, WriteFieldslem1BaseField> {
   using WriteFieldslege1RegisterFieldsType =
       WriteFieldslege1RegisterFields<BaseRegister, MightAllFieldsBeWritten,
                                      RegisterResetValue, WriteFieldslem1,
@@ -301,9 +299,8 @@ class WriteFieldslege1RegisterFields<BaseRegister, MightAllFieldsBeWritten,
   friend WriteFieldslep1Type<MightAllFieldsBeWritten>;
   friend WriteFieldslep1Type<false>;
   using WriteFieldslege1Type =
-      WriteFieldslege1<BaseRegister, MightAllFieldsBeWritten,
-                       RegisterResetValue, WriteFieldslem1,
-                       WriteFieldslem1BaseField>;
+      WriteFieldslege1<BaseRegister, false, RegisterResetValue,
+                       WriteFieldslem1, WriteFieldslem1BaseField>;
 
 protected:
   using WriteFieldslege1Type::getInverseMask;


### PR DESCRIPTION
The `write(BaseField)` member functions (inherited from the `WriteField0` and `WriteFieldslege1` class templates, which in turn inherit their `write` functions from the `Write` class template) of the base cases of the `WriteField0RegisterFields` and `WriteFieldslege1RegisterFields` class templates did not read if no fields had been skipped, but the `write(BaseField)` member functions of the base cases of the `WriteField0RegisterFields` and `WriteFieldslege1RegisterFields` class templates are called when the last field is skipped.